### PR TITLE
Update README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
       php-zip \
       php-soap \
       php-xdebug \
+      php-curl \
       composer
 
 COPY apache_default /etc/apache2/sites-available/000-default.conf

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ docker run -d -P bylexus/apache-php7
 With all the options:
 
 ```bash
-$ docker run -d -p 8080:80 \
+$ docker run -d -p 80:80 \
     -v /home/user/webroot:/var/www \
     -e PHP_ERROR_REPORTING='E_ALL & ~E_STRICT' \
     bylexus/apache-php7


### PR DESCRIPTION
Previously had an error connection refused. Fix "-p 8080:80" to "-p 80:80". Port 80 instead of 8080 was exposed in Dockerfile. Now it should work when trying to access from outside the container.